### PR TITLE
Fix #361: Ensure text remains visible during webfont load

### DIFF
--- a/primeicons.css
+++ b/primeicons.css
@@ -1,6 +1,6 @@
 @font-face {
     font-family: 'primeicons';
-    font-display: swap;
+    font-display: block;
     src: url('./fonts/primeicons.eot');
     src: url('./fonts/primeicons.eot?#iefix') format('embedded-opentype'), url('./fonts/primeicons.ttf') format('truetype'), url('./fonts/primeicons.woff') format('woff'), url('./fonts/primeicons.svg?#primeicons') format('svg');
     font-weight: normal;


### PR DESCRIPTION
From Google LightHouse suggestion: https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools

cc @onursenture 

![image](https://user-images.githubusercontent.com/4399574/138289212-03e1b724-5a0c-448b-a238-2a78834a4305.png)
