### PR TITLE
Font-family: "primeicons". Fixes #645

### DIFF
--- a/primeicons.css
+++ b/primeicons.css
@@ -1,5 +1,5 @@
 @font-face {
-    font-family: 'primeicons';
+    font-family: "primeicons";
     font-display: block;
     src: url('./fonts/primeicons.eot');
     src: url('./fonts/primeicons.eot?#iefix') format('embedded-opentype'), url('./fonts/primeicons.ttf') format('truetype'), url('./fonts/primeicons.woff') format('woff'), url('./fonts/primeicons.svg?#primeicons') format('svg');
@@ -21,7 +21,7 @@
 }
 
 .pi:before {
-    --webkit-backface-visibility:hidden;
+    --webkit-backface-visibility: hidden;
     backface-visibility: hidden;
 }
 
@@ -40,6 +40,7 @@
         -webkit-transform: rotate(0deg);
         transform: rotate(0deg);
     }
+
     100% {
         -webkit-transform: rotate(359deg);
         transform: rotate(359deg);
@@ -51,6 +52,7 @@
         -webkit-transform: rotate(0deg);
         transform: rotate(0deg);
     }
+
     100% {
         -webkit-transform: rotate(359deg);
         transform: rotate(359deg);
@@ -780,7 +782,7 @@
 .pi-refresh:before {
     content: "\e938";
 }
-  
+
 .pi-user:before {
     content: "\e939";
 }


### PR DESCRIPTION
Changed:
```css
font-family: 'primeicons';
```
into
```css
font-family: "primeicons";
```
as it caused the following error when imported in Nuxt 3 Vite projects:
ERROR: Failed to parse source for import analysis because the content contains invalid JS syntax. You may need to install appropriate plugins to handle the .css file format.